### PR TITLE
Use /usr/bin/env in shabangs

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Build the CRS Reports Archive website by generating its static content.
 #

--- a/bulk-download.py
+++ b/bulk-download.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Sample script to download CRS reports from EveryCRSReport.com.
 #
 # EveryCRSReport publishes a listing file at

--- a/process_incoming.py
+++ b/process_incoming.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import collections
 import datetime


### PR DESCRIPTION
This will use whatever python executable is on the PATH, which makes this virtualenv-compatible. I also made bulk-download.py executable and added a shabang to it.