### PR TITLE
Bulk download script fixes

### DIFF
--- a/bulk-download.py
+++ b/bulk-download.py
@@ -21,6 +21,7 @@ import io
 import csv
 import os, os.path
 import json
+import time
 
 api_base_url = "https://www.everycrsreport.com/"
 
@@ -47,6 +48,7 @@ def download_file(url, fn, expected_digest):
                 f.write(resp.read())
         except urllib.error.HTTPError as e:
             print("", e)
+    time.sleep(1)
 
 # Ensure output directories exist.
 os.makedirs("reports/reports", exist_ok=True)

--- a/bulk-download.py
+++ b/bulk-download.py
@@ -42,12 +42,13 @@ def download_file(url, fn, expected_digest):
 
     # Download and save the file.
     print(fn + "...")
-    with open(fn, 'wb') as f:
-        try:
-            with urllib.request.urlopen(url) as resp:
-                f.write(resp.read())
-        except urllib.error.HTTPError as e:
-            print("", e)
+    try:
+        with urllib.request.urlopen(url) as resp:
+            data = resp.read()
+            with open(fn, 'wb') as f:
+                f.write(data)
+    except urllib.error.HTTPError as e:
+        print("", e)
     time.sleep(1)
 
 # Ensure output directories exist.


### PR DESCRIPTION
I was getting 503 errors intermittently from the bulk download script. According to the documentation, 503 is used when rate limiting kicks in. This adds a simple sleep to slow down the bulk download script.

See also: https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html